### PR TITLE
Deploy rego file as configmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:opak8s.install"
+        "onCommand:opak8s.install",
+        "onCommand:opak8s.deployRego"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -19,6 +20,10 @@
             {
                 "command": "opak8s.install",
                 "title": "Install Open Policy Agent"
+            },
+            {
+                "command": "opak8s.deployRego",
+                "title": "Deploy Policy to Kubernetes"
             }
         ],
         "menus": {
@@ -27,6 +32,19 @@
                     "command": "opak8s.install",
                     "group": "80",
                     "when": "viewItem =~ /vsKubernetes\\.\\w*cluster($|[^.])/i"
+                }
+            ],
+            "editor/context": [
+                {
+                    "command": "opak8s.deployRego",
+                    "group": "99@1",
+                    "when": "editorLangId == rego"
+                }
+            ],
+            "commandPalette": [
+                {
+                    "command": "opak8s.deployRego",
+                    "when": "editorLangId == rego"
                 }
             ]
         }

--- a/src/commands/deploy-rego.ts
+++ b/src/commands/deploy-rego.ts
@@ -41,7 +41,7 @@ export async function deployRego(textEditor: vscode.TextEditor, edit: vscode.Tex
 async function createOrUpdateConfigMapFrom(deploymentInfo: DeploymentInfo, kubectl: k8s.KubectlV1): Promise<Errorable<null>> {
     const createResult = await kubectl.invokeCommand(`create configmap ${deploymentInfo.configmapName} --namespace=${OPA_NAMESPACE} --from-file=${deploymentInfo.fileName}=${deploymentInfo.filePath}`);
     if (createResult && createResult.code === 0) {
-        const annotateResult = await kubectl.invokeCommand(`annotate configmap ${deploymentInfo.configmapName} ${OPA_DEV_REGO_ANNOTATION}=true`);
+        const annotateResult = await kubectl.invokeCommand(`annotate configmap ${deploymentInfo.configmapName} --namespace=${OPA_NAMESPACE} ${OPA_DEV_REGO_ANNOTATION}=true`);
         if (!annotateResult || annotateResult.code !== 0) {
             return { succeeded: false, error: ['The policy was deployed successfully but you may not be able to update it'] };
         }

--- a/src/commands/deploy-rego.ts
+++ b/src/commands/deploy-rego.ts
@@ -9,5 +9,37 @@ export async function deployRego(textEditor: vscode.TextEditor, edit: vscode.Tex
         return;
     }
 
-    vscode.window.showInformationMessage("quick everybody look like you're deploying");
+    const uri = textEditor.document.uri;
+    if (uri.scheme === 'file') {
+        await textEditor.document.save();
+    } else {
+        // NOTE: we don't need to handle the 'untitled' case because the language ID
+        // won't be set until the document is saved
+        vscode.window.showErrorMessage('This command requires the document to be a file. Save your document to the file system and try again.');
+        return;
+    }
+
+    await createOrUpdateConfigMapFrom(uri);
+}
+async function createOrUpdateConfigMapFrom(uri: vscode.Uri) {
+    // kubectl create configmap somename --from-file=path/to/file ... --save-config=true?
+
+    // TODO: what if it already exists?
+    // DIAGNOSIS: kubectl create configmap returns code 1 and stderr contains the
+    // string "(AlreadyExists)"
+    // --save-config means we can apply a change but that requires
+    // us to compose the YAML in which case we might as well
+    // do that every time.  The way Brendan does this in the k8s extension is to
+    // download the CM from the cluster, modify the JSON, and do a replace...
+
+    // const dataHolderJson = await kubectl.asJson<DataHolder>(`get ${obj.kind.abbreviation} ${obj.name} --namespace=${currentNS} -o json`);
+    // dataHolder.data[fileName] = buff.toString();
+    // const out = JSON.stringify(dataHolder);
+    // await kubectl.invokeAsync(`replace -f - --namespace=${currentNS}`, out);
+
+    // TODO: want to annotate it so we know it was a dev deployment from the extension
+    // kubectl annotate configmap somename "k8s-opa-vscode.hestia.cc/devrego=true"
+    // NOTE: if we synthesise the YAML we can do this atomically
+
+    await vscode.window.showInformationMessage(`quick everybody look like you're deploying ${uri.toString()}`);
 }

--- a/src/commands/deploy-rego.ts
+++ b/src/commands/deploy-rego.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+import * as k8s from 'vscode-kubernetes-tools-api';
+import { showUnavailable } from '../utils/host';
+
+export async function deployRego(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) {
+    const kubectl = await k8s.extension.kubectl.v1;
+    if (!kubectl.available) {
+        await showUnavailable(kubectl.reason);
+        return;
+    }
+
+    vscode.window.showInformationMessage("quick everybody look like you're deploying");
+}

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { longRunning } from '../utils/host';
+import { longRunning, showUnavailable } from '../utils/host';
 import { withTempFile } from '../utils/tempfile';
 import { OPA_HELM_RELEASE_NAME, OPA_NAMESPACE } from '../opa';
 
@@ -123,16 +123,4 @@ data:
             reason = concat(", ", admission.deny)
             reason != ""
         }`;
-}
-
-async function showUnavailable(reason: "version-unknown" | "version-removed" | "extension-not-available") {
-    await vscode.window.showErrorMessage(unavailableMessage(reason));
-}
-
-function unavailableMessage(reason: "version-unknown" | "version-removed" | "extension-not-available"): string {
-    switch (reason) {
-        case "extension-not-available": return "Cannot run command: please check the 'Kubernetes' extension is installed";
-        case "version-removed": return "Cannot run command: please check for updates to the 'Open Policy Agent for Kubernetes' extension";
-        case "version-unknown": return "Cannot run command: please check for updates to the 'Kubernetes' extension";
-    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { install } from './commands/install';
+import { deployRego } from './commands/deploy-rego';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -12,8 +13,4 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
-}
-
-function deployRego(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) {
-    vscode.window.showInformationMessage("quick everybody look like you're deploying");
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,11 +4,16 @@ import { install } from './commands/install';
 export function activate(context: vscode.ExtensionContext) {
 
     const disposables = [
-        vscode.commands.registerCommand('opak8s.install', install)
+        vscode.commands.registerCommand('opak8s.install', install),
+        vscode.commands.registerTextEditorCommand('opak8s.deployRego', deployRego),
     ];
 
     context.subscriptions.push(...disposables);
 }
 
 export function deactivate() {
+}
+
+function deployRego(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) {
+    vscode.window.showInformationMessage("quick everybody look like you're deploying");
 }

--- a/src/opa.ts
+++ b/src/opa.ts
@@ -1,2 +1,3 @@
 export const OPA_HELM_RELEASE_NAME = 'opa';
 export const OPA_NAMESPACE = 'opa';
+export const OPA_DEV_REGO_ANNOTATION = 'k8s-opa-vscode.hestia.cc/devrego';

--- a/src/utils/errorable.ts
+++ b/src/utils/errorable.ts
@@ -1,0 +1,19 @@
+export interface Succeeded<T> {
+    readonly succeeded: true;
+    readonly result: T;
+}
+
+export interface Failed {
+    readonly succeeded: false;
+    readonly error: string[];
+}
+
+export type Errorable<T> = Succeeded<T> | Failed;
+
+export function succeeded<T>(e: Errorable<T>): e is Succeeded<T> {
+    return e.succeeded;
+}
+
+export function failed<T>(e: Errorable<T>): e is Failed {
+    return !e.succeeded;
+}

--- a/src/utils/host.ts
+++ b/src/utils/host.ts
@@ -34,3 +34,15 @@ export async function confirm(text: string, confirmLabel: string): Promise<boole
     const choice = await vscode.window.showWarningMessage(text, confirmLabel, 'Cancel');
     return choice === confirmLabel;
 }
+
+export async function showUnavailable(reason: "version-unknown" | "version-removed" | "extension-not-available") {
+    await vscode.window.showErrorMessage(unavailableMessage(reason));
+}
+
+function unavailableMessage(reason: "version-unknown" | "version-removed" | "extension-not-available"): string {
+    switch (reason) {
+        case "extension-not-available": return "Cannot run command: please check the 'Kubernetes' extension is installed";
+        case "version-removed": return "Cannot run command: please check for updates to the 'Open Policy Agent for Kubernetes' extension";
+        case "version-unknown": return "Cannot run command: please check for updates to the 'Kubernetes' extension";
+    }
+}


### PR DESCRIPTION
The OPA is installed to read from configmaps in the `opa` namespace.  This PR adds a way to quickly create or update such a configmap from the active Rego file, abstracting away the manual management of such config maps and associated mucking around with namespaces.