### PR TITLE
View policy errors and content

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "activationEvents": [
         "onCommand:opak8s.install",
         "onCommand:opak8s.deployRego",
+        "onCommand:opak8s.showPolicy",
         "onCommand:opak8s.deletePolicy",
         "onView:extension.vsKubernetesExplorer"
     ],
@@ -39,6 +40,10 @@
                 "title": "Deploy Policy to Kubernetes"
             },
             {
+                "command": "opak8s.showPolicy",
+                "title": "Show"
+            },
+            {
                 "command": "opak8s.deletePolicy",
                 "title": "Delete"
             }
@@ -49,6 +54,11 @@
                     "command": "opak8s.install",
                     "group": "80",
                     "when": "viewItem =~ /vsKubernetes\\.\\w*cluster($|[^.])/i"
+                },
+                {
+                    "command": "opak8s.showPolicy",
+                    "group": "70",
+                    "when": "viewItem =~ /opak8s\\.policy/i"
                 },
                 {
                     "command": "opak8s.deletePolicy",
@@ -67,6 +77,10 @@
                 {
                     "command": "opak8s.deployRego",
                     "when": "editorLangId == rego"
+                },
+                {
+                    "command": "opak8s.showPolicy",
+                    "when": "never"
                 },
                 {
                     "command": "opak8s.deletePolicy",

--- a/src/commands/show-policy.ts
+++ b/src/commands/show-policy.ts
@@ -19,5 +19,18 @@ export async function showPolicy(target: any) {
 }
 
 async function tryShowPolicy(policy: ConfigMap): Promise<void> {
-    await vscode.window.showInformationMessage(`imagine all the useful info about ${policy.metadata.name}`);
+    const markdown = renderMarkdown(policy);
+    const html = await vscode.commands.executeCommand<string>('markdown.api.render', markdown);
+    if (!html) {
+        await vscode.window.showErrorMessage("Can't show policy: internal error");
+        return;
+    }
+
+    const webview = vscode.window.createWebviewPanel('opak8s-policy-view', policy.metadata.name, vscode.ViewColumn.Active, { enableFindWidget: true });
+    webview.webview.html = html;
+    webview.reveal();
+}
+
+function renderMarkdown(policy: ConfigMap): string {
+    return `# Meet my policy ${policy.metadata.name}`;
 }

--- a/src/commands/show-policy.ts
+++ b/src/commands/show-policy.ts
@@ -38,6 +38,7 @@ function renderMarkdown(policy: ConfigMap): string {
     return definedOf(renderErrorMarkdown(policy), renderRegoMarkdown(policy)).join('\n\n---\n\n');
 }
 
+// TODO: I wonder if we should organise it by file rather than having all the errors at the top?
 function renderErrorMarkdown(policy: ConfigMap): string | undefined {
     const error = policyError(policy);
     if (!error) {

--- a/src/commands/show-policy.ts
+++ b/src/commands/show-policy.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+import * as k8s from 'vscode-kubernetes-tools-api';
+import { unavailableMessage } from '../utils/host';
+import { PolicyBrowser } from '../ui/policy-browser';
+import { ConfigMap } from '../opa';
+
+export async function showPolicy(target: any) {
+    const clusterExplorer = await k8s.extension.clusterExplorer.v1;
+    if (!clusterExplorer.available) {
+        await vscode.window.showWarningMessage(`Can't run command: ${unavailableMessage(clusterExplorer.reason)}`);
+        return;
+    }
+
+    const node = PolicyBrowser.resolve(target, clusterExplorer.api);
+    if (node && node.nodeType === 'policy') {
+        const policy = node.configmap;
+        await tryShowPolicy(policy);
+    }
+}
+
+async function tryShowPolicy(policy: ConfigMap): Promise<void> {
+    await vscode.window.showInformationMessage(`imagine all the useful info about ${policy.metadata.name}`);
+}

--- a/src/commands/show-policy.ts
+++ b/src/commands/show-policy.ts
@@ -21,12 +21,13 @@ export async function showPolicy(target: any) {
 
 async function tryShowPolicy(policy: ConfigMap): Promise<void> {
     const markdown = renderMarkdown(policy);
-    console.log(markdown);
-    const html = await vscode.commands.executeCommand<string>('markdown.api.render', markdown);
-    if (!html) {
+    const mdhtml = await vscode.commands.executeCommand<string>('markdown.api.render', markdown);
+    if (!mdhtml) {
         await vscode.window.showErrorMessage("Can't show policy: internal error");
         return;
     }
+
+    const html = `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none';"><head><body>${mdhtml}</body></html>`;
 
     const webview = vscode.window.createWebviewPanel('opak8s-policy-view', policy.metadata.name, vscode.ViewColumn.Active, { enableFindWidget: true });
     webview.webview.html = html;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,12 +4,14 @@ import { install } from './commands/install';
 import { deployRego } from './commands/deploy-rego';
 import { unavailableMessage } from './utils/host';
 import { PolicyBrowser } from './ui/policy-browser';
+import { showPolicy } from './commands/show-policy';
 import { deletePolicy } from './commands/delete-policy';
 
 export async function activate(context: vscode.ExtensionContext) {
     const disposables = [
         vscode.commands.registerCommand('opak8s.install', install),
         vscode.commands.registerTextEditorCommand('opak8s.deployRego', deployRego),
+        vscode.commands.registerCommand('opak8s.showPolicy', showPolicy),
         vscode.commands.registerCommand('opak8s.deletePolicy', deletePolicy),
     ];
 

--- a/src/opa.ts
+++ b/src/opa.ts
@@ -36,6 +36,25 @@ export function policyIsDevRego(configmap: ConfigMap): boolean {
     return !!annotations[OPA_DEV_REGO_ANNOTATION];
 }
 
+export function policyError(configmap: ConfigMap): PolicyError | undefined {
+    const annotations = configmap.metadata.annotations;
+    if (!annotations) {
+        return undefined;
+    }
+
+    const statusText = annotations[OPA_POLICY_STATUS_ANNOTATION];
+    if (!statusText) {
+        return undefined;
+    }
+
+    const status = JSON.parse(statusText);
+    if (status.status !== 'error') {
+        return undefined;
+    }
+
+    return status.error;
+}
+
 export enum PolicyStatus {
     Unevaluated,
     Valid,
@@ -51,5 +70,21 @@ export interface ConfigMap {
     readonly metadata: {
         readonly name: string;
         readonly annotations?: { [key: string]: string }
+    };
+}
+
+export interface PolicyError {
+    readonly code: string;
+    readonly message: string;
+    readonly errors?: ReadonlyArray<PolicyErrorDetail>;
+}
+
+export interface PolicyErrorDetail {
+    readonly code: string;
+    readonly message: string;
+    readonly location: {
+        readonly file: string;
+        readonly row: number;
+        readonly col: number;
     };
 }

--- a/src/ui/policy-browser.ts
+++ b/src/ui/policy-browser.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { isSystemConfigMap, OPA_NAMESPACE, GetConfigMapsResponse, ConfigMap, policyStatus, PolicyStatus, policyIsDevRego } from '../opa';
+import { isSystemConfigMap, OPA_NAMESPACE, GetConfigMapsResponse, ConfigMap, policyStatus, PolicyStatus, policyIsDevRego, policyError } from '../opa';
 import { definedOf } from '../utils/array';
 
 export namespace PolicyBrowser {
@@ -91,7 +91,7 @@ class PolicyNode implements k8s.ClusterExplorerV1.Node, PolicyBrowser.PolicyNode
     }
     private statusTooltipPart(): string {
         switch (policyStatus(this.configmap)) {
-            case PolicyStatus.Error: return 'Policy has errors';
+            case PolicyStatus.Error: return `Error: ${policyError(this.configmap)!.message}`;
             case PolicyStatus.Valid: return 'Valid';
             case PolicyStatus.Unevaluated: return 'Not evaluated by OPA';
         }


### PR DESCRIPTION
Adds a 'Show' command to policies, which displays the policy Rego in a webview, together with any errors.  It's not quite as nice as a text view with squigglies though...