### PR TITLE
Open source file from a policy in the tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "onCommand:opak8s.install",
         "onCommand:opak8s.deployRego",
         "onCommand:opak8s.showPolicy",
+        "onCommand:opak8s.findFileInWorkspace",
         "onCommand:opak8s.deletePolicy",
         "onView:extension.vsKubernetesExplorer"
     ],
@@ -44,6 +45,10 @@
                 "title": "Show"
             },
             {
+                "command": "opak8s.findFileInWorkspace",
+                "title": "Find File in Workspace"
+            },
+            {
                 "command": "opak8s.deletePolicy",
                 "title": "Delete"
             }
@@ -57,7 +62,12 @@
                 },
                 {
                     "command": "opak8s.showPolicy",
-                    "group": "70",
+                    "group": "70@1",
+                    "when": "viewItem =~ /opak8s\\.policy/i"
+                },
+                {
+                    "command": "opak8s.findFileInWorkspace",
+                    "group": "70@2",
                     "when": "viewItem =~ /opak8s\\.policy/i"
                 },
                 {
@@ -80,6 +90,10 @@
                 },
                 {
                     "command": "opak8s.showPolicy",
+                    "when": "never"
+                },
+                {
+                    "command": "opak8s.findFileInWorkspace",
                     "when": "never"
                 },
                 {

--- a/src/commands/find-file-in-workspace.ts
+++ b/src/commands/find-file-in-workspace.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+import * as k8s from 'vscode-kubernetes-tools-api';
+import { unavailableMessage } from '../utils/host';
+import { PolicyBrowser } from '../ui/policy-browser';
+import { ConfigMap } from '../opa';
+
+export async function findFileInWorkspace(target: any) {
+    const clusterExplorer = await k8s.extension.clusterExplorer.v1;
+    if (!clusterExplorer.available) {
+        await vscode.window.showWarningMessage(`Can't run command: ${unavailableMessage(clusterExplorer.reason)}`);
+        return;
+    }
+
+    const node = PolicyBrowser.resolve(target, clusterExplorer.api);
+    if (node && node.nodeType === 'policy') {
+        const policy = node.configmap;
+        await tryOpenWorkspaceFile(policy);
+    }
+}
+
+async function tryOpenWorkspaceFile(policy: ConfigMap): Promise<void> {
+    await vscode.window.showInformationMessage(`pretending to open source file of ${policy.metadata.name}`);
+}

--- a/src/commands/find-file-in-workspace.ts
+++ b/src/commands/find-file-in-workspace.ts
@@ -39,12 +39,12 @@ async function tryFindSourceFile(policy: ConfigMap): Promise<Errorable<vscode.Ur
     if (policyRegoKeys.length === 0) {
         return { succeeded: false, error: ["Policy configmap doesn't list any .rego files"] };
     }
-    if (policyRegoKeys.length > 1) {
-        // TODO: consider prompting for which one to open
-        return { succeeded: false, error: ["Policy configmap lists more than one .rego file"] };
-    }
 
-    const sourceFileName = policyRegoKeys[0];
+    const sourceFileName = await selectQuickPickOf(policyRegoKeys, (s) => s, { placeHolder: 'Policy contains multiple files - choose one to find' });
+
+    if (!sourceFileName) {
+        return { succeeded: true, result: undefined };  // cancelled
+    }
     const matches = await vscode.workspace.findFiles(`**/${sourceFileName}`);
 
     if (matches.length === 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,12 +6,14 @@ import { unavailableMessage } from './utils/host';
 import { PolicyBrowser } from './ui/policy-browser';
 import { showPolicy } from './commands/show-policy';
 import { deletePolicy } from './commands/delete-policy';
+import { findFileInWorkspace } from './commands/find-file-in-workspace';
 
 export async function activate(context: vscode.ExtensionContext) {
     const disposables = [
         vscode.commands.registerCommand('opak8s.install', install),
         vscode.commands.registerTextEditorCommand('opak8s.deployRego', deployRego),
         vscode.commands.registerCommand('opak8s.showPolicy', showPolicy),
+        vscode.commands.registerCommand('opak8s.findFileInWorkspace', findFileInWorkspace),
         vscode.commands.registerCommand('opak8s.deletePolicy', deletePolicy),
     ];
 

--- a/src/utils/host.ts
+++ b/src/utils/host.ts
@@ -22,6 +22,15 @@ export async function selectQuickPick<T extends vscode.QuickPickItem>(items: T[]
     return await vscode.window.showQuickPick(items, options);
 }
 
+export async function selectQuickPickOf<T>(items: T[], label: (item: T) => string, options?: vscode.QuickPickOptions): Promise<T | undefined> {
+    const picks = items.map((item) => ({ label: label(item), value: item }));
+    const pick = await selectQuickPick(picks, options);
+    if (pick) {
+        return pick.value;
+    }
+    return undefined;
+}
+
 export async function longRunning<T>(title: string, action: () => Promise<T>): Promise<T> {
     const options = {
         location: vscode.ProgressLocation.Notification,


### PR DESCRIPTION
Allows users to right-click on a policy in the OPA Policies folder and it will try to find the source file in the current workspace and open it for partying on.